### PR TITLE
feat: add sidebar to main page

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -3,7 +3,7 @@
 
 title: LavaMoat
 description: Secure your JavaScript with LavaMoat.
-template: splash
+template: doc
 hero:
   tagline: Proactive supply-chain security at runtime
   image:


### PR DESCRIPTION
switched main page to have the default layout instead of the splash. It adds both sidebars. Is that what we wanted?

Screenshots of various widths
![Screenshot 2024-09-18 at 10-34-18 LavaMoat LavaMoat](https://github.com/user-attachments/assets/9dff89db-1c3c-4242-b72a-cf729e90d841)
---
![Screenshot 2024-09-18 at 10-34-05 LavaMoat LavaMoat](https://github.com/user-attachments/assets/4b340156-8a85-45f4-988e-9d5424309522)
---
![Screenshot 2024-09-18 at 10-33-49 LavaMoat LavaMoat](https://github.com/user-attachments/assets/990b9300-e638-4ac4-a9bb-34acc4718393)


