### PR TITLE
Bump GitHub action workflows to their latest versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Install, build, and upload your site output
-        uses: withastro/action@v2
+        uses: withastro/action@v6
         with:
-          node-version: 20
+          node-version: 24
 
   deploy:
     needs: build

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -12,6 +12,6 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: npm ci
       - run: npm run lint:eslint

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -12,6 +12,6 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: npm ci
       - run: npm run lint:markdown

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,6 +12,6 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: npm ci
       - run: npm run format:check

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -12,6 +12,6 @@ jobs:
   tsc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: npm ci
       - run: npm run -- tsc --extendedDiagnostics


### PR DESCRIPTION
This PR bumps GitHub action workflows to their latest versions, thus avoiding deprecation warnings as e.g. seen [here](https://github.com/LavaMoat/lavamoat.github.io/actions/runs/23313555635):

```
Node.js 20 actions are deprecated.
The following actions are running on Node.js 20 and may not work as expected:
actions/checkout@v3.
```