### PR TITLE
chore: update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,20 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'config:recommended',
+    'group:definitelyTyped', // groups all `@types/*` packages together
+    'helpers:pinGitHubActionDigests', // pins SHAs of GitHub actions
+    ':enableVulnerabilityAlerts', // enables GitHub vulnerability alerts
+    ':semanticCommits', // use semantic commits
+    'group:linters', // group lint-related packages together
+    'workarounds:typesNodeVersioning', // tracks node versions from engines field in package.json for @types/node,
+    'helpers:disableTypesNodeMajor', // disable major updates for @types/node. TODO: we will need to do this manually when dropping v18
+  ],
+  schedule: '* 0-6 * * *', // run things only during 0-6am UTC
+  packageRules: [
+    {
+      groupName: 'astro',
+      matchPackageNames: ['astro', 'astro-embed', '@astrojs/*'],
+    },
+  ],
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,8 +11,11 @@ export default [
   { languageOptions: { globals: globals.browser } },
   pluginJs.configs.recommended,
   ...astro.configs['flat/recommended'],
-  ...jsonc.configs['flat/prettier'],
   ...tseslint.configs.recommended,
+  ...jsonc.configs['flat/prettier'].map((config) => ({
+    ...config,
+    files: ['**/tsconfig*.json', '**/*.json5', '**/*.jsonc'],
+  })),
   {
     ignores: ['.astro/**/*', '**/env.d.ts', 'dist/**'],
   },

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}


### PR DESCRIPTION
This updates the Renovate config so that it groups Astro-related and linter-related updates together, along with several other settings copied over from LavaMoat.

As a bonus, it fixes the failing Prettier job.