### PR TITLE
fix: force-upgrade yaml across the board

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10882,18 +10882,6 @@
       "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
       "license": "MIT"
     },
-    "node_modules/yaml-language-server/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepare": "husky",
     "preview": "astro preview",
     "start": "astro dev",
+    "test": "node --run check && node --run lint",
     "tsc": "tsc",
     "tsc:config": "tsc --showConfig"
   },
@@ -47,6 +48,9 @@
     "prettier-plugin-pkg": "0.22.1",
     "sharp": "0.34.5",
     "typescript-eslint": "8.59.4"
+  },
+  "overrides": {
+    "yaml": ">=2.8.3"
   },
   "lint-staged": {
     "*.(m?js|ts)": [


### PR DESCRIPTION
Ref: [CVE-2026-33532](https://nvd.nist.gov/vuln/detail/CVE-2026-33532)

Also add a `test` script for fun.

The override should be removed when `@astrojs/check` no longer has a transitive dep on the vuln version of `yaml`.